### PR TITLE
Remove extend touchable region for AOSP keyboard

### DIFF
--- a/java/src/com/android/inputmethod/latin/LatinIME.java
+++ b/java/src/com/android/inputmethod/latin/LatinIME.java
@@ -117,7 +117,6 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
     static final String TAG = LatinIME.class.getSimpleName();
     private static final boolean TRACE = false;
 
-    private static final int EXTENDED_TOUCHABLE_REGION_HEIGHT = 100;
     private static final int PERIOD_FOR_AUDIO_AND_HAPTIC_FEEDBACK_IN_KEY_REPEAT = 2;
     private static final int PENDING_IMS_CALLBACK_DURATION_MILLIS = 800;
     static final long DELAY_WAIT_FOR_DICTIONARY_LOAD_MILLIS = TimeUnit.SECONDS.toMillis(2);
@@ -1211,9 +1210,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
             final int touchLeft = 0;
             final int touchTop = mKeyboardSwitcher.isShowingMoreKeysPanel() ? 0 : visibleTopY;
             final int touchRight = visibleKeyboardView.getWidth();
-            final int touchBottom = inputHeight
-                    // Extend touchable region below the keyboard.
-                    + EXTENDED_TOUCHABLE_REGION_HEIGHT;
+            final int touchBottom = inputHeight;
             outInsets.touchableInsets = InputMethodService.Insets.TOUCHABLE_INSETS_REGION;
             outInsets.touchableRegion.set(touchLeft, touchTop, touchRight, touchBottom);
         }


### PR DESCRIPTION
Remove EXTENDED_TOUCHABLE_REGION_HEIGHT from LatinIME#onComputeInsets
to prevent keyboard touch region covered navigation bar
when in split-window mode with display density < 240 case.

Fix: 134893742
Test: manual as below steps:
1) Set window density as 240 with "adb shell wm density 240"
2) Launch a app (i.e. Messages) from recents activity, set as split-screen mode.
3) Tap Search bar to show IME keyboard.
4) Press home / back / recents key if it works, expect it works.

Change-Id: I596b7276041fecc50d2bc095c7e51664f632368d